### PR TITLE
feat: 애플리케이션 포트를 8001로 변경

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY app/ ./app/
 
 # 포트 노출
-EXPOSE 8002
+EXPOSE 8001
 
 # 애플리케이션 실행
-CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8002"]
+CMD ["uvicorn", "app.main:app", "--host", "0.0.0.0", "--port", "8001"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,7 +5,7 @@ services:
   app:
     build: .
     ports:
-      - "8002:8002"
+      - "8001:8001"
     environment:
       - MONGODB_URL=mongodb://mongodb:27017
       - DATABASE_NAME=purchase_dashboard

--- a/nginx.conf
+++ b/nginx.conf
@@ -4,7 +4,7 @@ events {
 
 http {
     upstream app {
-        server app:8002;
+        server app:8001;
     }
 
     # Rate limiting


### PR DESCRIPTION
- Dockerfile: uvicorn 실행 시 포트 8001 사용 및 EXPOSE 8001
- docker-compose.yml: app 서비스 포트 매핑을 8001:8001로 변경
- nginx.conf: upstream 설정을 app:8001로 변경
- Docker 이미지 재빌드 및 컨테이너 재시작 완료